### PR TITLE
Fixes web page parsing for XKCD layout changes

### DIFF
--- a/extras/xkcdWatcher.py
+++ b/extras/xkcdWatcher.py
@@ -3,25 +3,25 @@ import webbrowser
 import lxml.html
 import time
 
-CHECK_DELAY = 1 * 60 * 60  # 1 hour * 60 min * 60 seconds 
-## CHECK_DELAY = 10 ## testing mode 
+CHECK_DELAY = 1 * 60 * 60  # 1 hour * 60 min/hr * 60 seconds/min = 3600 secs = 1 hr
+# CHECK_DELAY = 10 ## 10 seconds in testing mode 
 
-sp = serial.Serial("/dev/ttyUSB0", 38400, timeout = 2)
+sp = serial.Serial("/dev/tty.usbserial-AM01QY9L", 38400, timeout = 2)
 sp.flush()  # clear out whatever junk is in the serial buffer
 
 def whichXKCD():
     '''Fetches the XKCD website and parses out the current comic number'''
     xkcd = lxml.html.parse("http://www.xkcd.com")
     comicDiv = xkcd.getroot().get_element_by_id("comic")
-    comicLink = comicDiv[0].attrib['href']
+    comicLink = comicDiv[0].attrib['src']
     try:    
-        comicNumber = int(comicLink.split("/")[3])   ## (@_@) don't like this so checking integer type 
+        comicName = comicLink.split("/")[4]   
     except ValueError:  ## it wasn't able to convert to integer
         raise RuntimeError("can't parse the link: %s" % comicLink)
-    return comicNumber
+    return comicName
     
-lastXKCD = 1   
-## Set to cartoon number one -- will alert you on first check 
+lastXKCD = ""   
+## Set to blank cartoon -- will alert you on first check 
 lastTime = time.time()
 
 while(True):                    # endless loop
@@ -39,10 +39,9 @@ while(True):                    # endless loop
     if (thisTime - lastTime) > CHECK_DELAY:
         currentXKCD = whichXKCD()
         lastTime = thisTime
-        print "Current XKCD: %d" % currentXKCD
+        print "Current XKCD: %s" % currentXKCD
         
         if not lastXKCD == currentXKCD:
             ## Warn the user!
             sp.write('L')
             lastXKCD = currentXKCD
-

--- a/extras/xkcdWatcher.py
+++ b/extras/xkcdWatcher.py
@@ -4,9 +4,9 @@ import lxml.html
 import time
 
 CHECK_DELAY = 1 * 60 * 60  # 1 hour * 60 min/hr * 60 seconds/min = 3600 secs = 1 hr
-# CHECK_DELAY = 10 ## 10 seconds in testing mode 
+## CHECK_DELAY = 10 ## 10 seconds in testing mode 
 
-sp = serial.Serial("/dev/tty.usbserial-AM01QY9L", 38400, timeout = 2)
+sp = serial.Serial("/dev/ttyUSB0", 38400, timeout = 2)
 sp.flush()  # clear out whatever junk is in the serial buffer
 
 def whichXKCD():
@@ -15,7 +15,7 @@ def whichXKCD():
     comicDiv = xkcd.getroot().get_element_by_id("comic")
     comicLink = comicDiv[0].attrib['src']
     try:    
-        comicName = comicLink.split("/")[4]   
+        comicName = comicLink.split("/")[4]   ## Get the name of the comic PNG file
     except ValueError:  ## it wasn't able to convert to integer
         raise RuntimeError("can't parse the link: %s" % comicLink)
     return comicName


### PR DESCRIPTION
The XKCD web page layout changed, causing the whichXKCD() method to throw an error due to the missing 'href' attrib.  The modified code uses the PNG file name of the comic to check for a new comic.
